### PR TITLE
Add keys to array elements

### DIFF
--- a/404.jsx
+++ b/404.jsx
@@ -43,9 +43,9 @@ text: >-
   help.
 ---
 <Container px={3} py={3}>
-  <SiteHeader 
+  <SiteHeader
     src={props.avatar}
-    links={props.links} 
+    links={props.links}
   />
 </Container>
 <HorizontalRule color='black25' />
@@ -55,7 +55,7 @@ text: >-
   <PageSubtitle children={props.subtitle} />
   <Text children={props.text} />
   {(props.links || []).map((item, index) => (
-    <NavLink ml={0} mr={4} children={item.text} />
+    <NavLink key={index} ml={0} mr={4} children={item.text} />
   ))}
 </Container>
 <HorizontalRule color='black25' />

--- a/FullPage.jsx
+++ b/FullPage.jsx
@@ -29,8 +29,8 @@ text: >-
 ---
 <PageBG image='https://mrmrs.github.io/photos/u/050.jpg' p={5}>
   <Flex justify='center'>
-  {(props.links || []).map(link => (
-    <NavLink mx={3} href={link.href} >{link.text}</NavLink>
+  {(props.links || []).map((link, i) => (
+    <NavLink key={i} mx={3} href={link.href} >{link.text}</NavLink>
   ))}
   </Flex>
   <Flex align='center' justify='center' style={{height: '100%' }}>
@@ -39,10 +39,10 @@ text: >-
       <PageTitle  children={props.title} />
       <PageSubtitle  children={props.subtitle} />
       <Text  mx='auto' children={props.text} />
-    </Center > 
+    </Center >
   </Flex>
   <footer style={{ position: 'absolute', bottom: 0 , right: 0, left: 0}}>
-    <Div pb={4}>     
+    <Div pb={4}>
       <Flex pt={4} pb={2} justify='center' ml='auto'>
         {props.facebook && <FacebookIcon mb={2} href={props.facebook} /> }
         {props.twitter && <TwitterIcon mb={2} href={'https://twitter.com/'+props.twitter} /> }

--- a/Index.jsx
+++ b/Index.jsx
@@ -127,9 +127,9 @@ tiles:
 ---
 <Box>
   <Container px={3} py={3}>
-    <SiteHeader 
+    <SiteHeader
       src={props.avatar}
-      links={props.links} 
+      links={props.links}
     />
   </Container>
   <HorizontalRule color='black25' />
@@ -144,12 +144,12 @@ tiles:
 <Container pb={5} px={2}>
   <SectionTitle children='Projects' mx={2} />
   {/* For a single item gallery. Sets card to full width.  */}
-  {props.cards.length == 1 && 
+  {props.cards.length == 1 &&
     <Flex wrap mx={0}>
       {(props.cards || []).map((card, index) => (
-        <Box px={2} mb={4} w={1}>
-          <Card 
-             src={card.src} 
+        <Box key={index} px={2} mb={4} w={1}>
+          <Card
+             src={card.src}
              title={card.title}
              subtitle={card.subtitle}
              text={card.text}
@@ -158,14 +158,14 @@ tiles:
       ))}
     </Flex>
   }
-  
+
   {/* For lists that contain a multiple of 3 items, set column width to 1/3 */}
-  {props.cards.length % 3 == 0 && 
+  {props.cards.length % 3 == 0 &&
     <Flex wrap mx={0}>
       {(props.cards || []).map((card, index) => (
-        <Box px={2} mb={4} w={[1,1/3]}>
-          <Card 
-             src={card.src} 
+        <Box key={index} px={2} mb={4} w={[1,1/3]}>
+          <Card
+             src={card.src}
              title={card.title}
              subtitle={card.subtitle}
              text={card.text}
@@ -179,9 +179,9 @@ tiles:
   {props.cards.length % 2 == 0 && props.cards.length % 3 != 0 &&
     <Flex wrap mx={0}>
       {(props.cards || []).map((card, index) => (
-        <Box px={2} mb={4} w={[1,1/2]}>
-          <Card 
-             src={card.src} 
+        <Box key={index} px={2} mb={4} w={[1,1/2]}>
+          <Card
+             src={card.src}
              title={card.title}
              subtitle={card.subtitle}
              text={card.text}
@@ -194,8 +194,8 @@ tiles:
   {props.cards.length == 5 &&
     <Flex wrap mx={0}>
       {(props.cards || []).map((card, index) => (
-        <Box px={2} mb={4} w={index < props.cards.length -2 ? [ 1, 1/3 ] : [ 1, 1/2 ]}>
-          <Card 
+        <Box key={index} px={2} mb={4} w={index < props.cards.length -2 ? [ 1, 1/3 ] : [ 1, 1/2 ]}>
+          <Card
              src={card.src}
              title={card.title}
              subtitle={card.subtitle}
@@ -209,8 +209,8 @@ tiles:
   {props.cards.length == 10 &&
     <Flex wrap mx={0}>
       {(props.cards || []).map((card, index) => (
-        <Box px={2} mb={4} w={index < props.cards.length -4 ? [ 1, 1/3 ] : [ 1, 1/4]}>
-          <Card 
+        <Box key={index} px={2} mb={4} w={index < props.cards.length -4 ? [ 1, 1/3 ] : [ 1, 1/4]}>
+          <Card
              src={card.src}
              title={card.title}
              subtitle={card.subtitle}
@@ -220,14 +220,14 @@ tiles:
      ))}
     </Flex>
   }
-  {/* 
+  {/*
      For lists with 7 items
   */}
-  {props.cards.length == 7 && 
+  {props.cards.length == 7 &&
     <Flex wrap mx={0}>
       {(props.cards || []).map((card, index) => (
-        <Box px={2} mb={4} w={index < props.cards.length -4 ? [ 1, 1/3 ] : [ 1, 1/4 ]}>
-          <Card 
+        <Box key={index} px={2} mb={4} w={index < props.cards.length -4 ? [ 1, 1/3 ] : [ 1, 1/4 ]}>
+          <Card
              src={card.src}
              title={card.title}
              subtitle={card.subtitle}
@@ -237,15 +237,15 @@ tiles:
      ))}
     </Flex>
   }
-  {/* 
+  {/*
     For lists that have a prime number of items after 7.
     Set first item to full width, and the rest to half width.
   */}
-  {props.cards.length % 2 != 0 && props.cards.length %3 !=0 && props.cards.length % 5 && props.cards.length % 7 != 0 && 
+  {props.cards.length % 2 != 0 && props.cards.length %3 !=0 && props.cards.length % 5 && props.cards.length % 7 != 0 &&
     <Flex wrap mx={0}>
       {(props.cards || []).map((card, index) => (
-        <Box px={2} mb={4} w={index == 0 ? [ 1 ] : [ 1, 1/2 ]}>
-          <Card 
+        <Box key={index} px={2} mb={4} w={index == 0 ? [ 1 ] : [ 1, 1/2 ]}>
+          <Card
              src={card.src}
              title={card.title}
              subtitle={card.subtitle}
@@ -259,8 +259,8 @@ tiles:
 {props.tiles.length%2 == 1 &&
   <Flex color='white' wrap mx={0}>
   {(props.tiles || []).map((tile, index) => (
-    <Box px={2} mb={4} w={index === props.tiles.length -1 ? 1 : [1, 1/2]}>
-      <Tile 
+    <Box key={index} px={2} mb={4} w={index === props.tiles.length -1 ? 1 : [1, 1/2]}>
+      <Tile
        color={tile.color}
        src={tile.src}
        title={tile.title}
@@ -276,8 +276,8 @@ tiles:
 {props.tiles.length%2 == 0 &&
   <Flex color='white' wrap mx={0}>
     {(props.tiles || []).map((tile, index) => (
-      <Box px={2} mb={4} w={[1, 1/2]}>
-        <Tile 
+      <Box key={index} px={2} mb={4} w={[1, 1/2]}>
+        <Tile
          color={tile.color}
          src={tile.src}
          title={tile.title}
@@ -293,10 +293,10 @@ tiles:
   <Box px={2} mb={5}>
     <SectionTitle children='Case studies' mb={4} />
     {(props.panels || []).map((panel, index) => (
-      <Box mb={5}>
+      <Box key={index} mb={5}>
         {index % 2 == 0 &&
-          <Panel 
-             title={panel.title} 
+          <Panel
+             title={panel.title}
              subtitle={panel.subtitle}
              linkText={panel.linkText}
              text={panel.text}
@@ -304,7 +304,7 @@ tiles:
         }
         {index % 2 == 1 &&
           <PanelAlt
-             title={panel.title} 
+             title={panel.title}
              subtitle={panel.subtitle}
              linkText={panel.linkText}
              text={panel.text}

--- a/Project.jsx
+++ b/Project.jsx
@@ -69,9 +69,9 @@ cards:
 ---
 <Box>
 <Container px={3} py={3}>
-<SiteHeader 
+<SiteHeader
 src={props.avatar}
-links={props.links} 
+links={props.links}
 />
 </Container>
 <HorizontalRule color='black25' />
@@ -107,8 +107,8 @@ links={props.links}
   </Text>
   <SectionTitle mt={6} mb={3} children='Other Projects' />
   <Flex nowrap mx={-2} mb={4}>
-    {(props.cards || []).map(item => (
-      <Box px={2} mb={3} w={[1]}>
+    {(props.cards || []).map((item, i) => (
+      <Box key={i} px={2} mb={3} w={[1]}>
         <Tile src={item.src} href={item.link} />
       </Box>
     ))}

--- a/VerticalGrid.jsx
+++ b/VerticalGrid.jsx
@@ -36,9 +36,9 @@ cards:
   - src: 'https://c8r.imgix.net/e5b389e680cafc83d5f4f383/42.jpg?w=720&fit=clip'
 ---
 <Container px={3} py={3}>
-  <SiteHeader 
+  <SiteHeader
     src={props.avatar}
-    links={props.links} 
+    links={props.links}
   />
 </Container>
 <HorizontalRule color='black25' />
@@ -46,16 +46,16 @@ cards:
   <Flex px={2} mt={3}>
     <Box w={1/3} px={2}>
       {(props.cards || []).map((card, index) => (
-        <Box>
-          {index % 3 == 2 && 
-            <Card src={card.src} /> 
+        <Box key={index}>
+          {index % 3 == 2 &&
+            <Card src={card.src} />
           }
         </Box>
       ))}
     </Box>
     <Box w={1/3} px={2}>
       {(props.cards || []).map((card, index) => (
-        <Box>
+        <Box key={index}>
           {index % 3 == 1 &&
             <Card src={card.src} />
           }
@@ -64,7 +64,7 @@ cards:
     </Box>
     <Box w={1/3} px={2}>
       {(props.cards || []).map((card, index) => (
-        <Box>
+        <Box key={index}>
           {index % 3 == 0 &&
             <Card src={card.src} />
           }

--- a/lab.json
+++ b/lab.json
@@ -964,7 +964,7 @@
         "Div",
         "BlockLink"
       ],
-      "jsx": "<header>\n<Flexbox>\n  <BlockLink href=\"/\">\n    <Avatar src={props.src} />\n  </BlockLink>\n  <Div ml='auto'>\n  {(props.links || []).map(link => (\n    <NavLink href={link.href} >{link.text}</NavLink>\n  ))}\n  </Div>\n  </Flexbox>\n</header>",
+      "jsx": "<header>\n<Flexbox>\n  <BlockLink href=\"/\">\n    <Avatar src={props.src} />\n  </BlockLink>\n  <Div ml='auto'>\n  {(props.links || []).map((link, i) => (\n    <NavLink key={i} href={link.href} >{link.text}</NavLink>\n  ))}\n  </Div>\n  </Flexbox>\n</header>",
       "examples": [
         "<SiteHeader \nsrc='https://c8r.imgix.net/87760e0718677237f07e486c/timothy.jpg'\nlinks={[\n  {\n    href: '#0', \n    text: 'Writing' \n  },\n  {\n    href: '#0', \n    text: 'Work' \n  },\n  {\n    href: '#0', \n    text: 'projects' \n  },\n  {\n    href: '#0', \n    text: 'Case Studies' \n  },\n   {\n    href: '#0', \n    text: 'hi@email.com' \n  },\n    ]} />"
       ],
@@ -1215,7 +1215,7 @@
         "ListItem",
         "ListItemLink"
       ],
-      "jsx": "<List>\n  {(props.links || []).map(link => (\n    <ListItem w={[ 1, 1/3, 1/4 ]}><ListItemLink href={link.href} >{link.text}</ListItemLink></ListItem>\n  ))}\n</List>",
+      "jsx": "<List>\n  {(props.links || []).map((link, i) => (\n    <ListItem key={i} w={[ 1, 1/3, 1/4 ]}><ListItemLink href={link.href} >{link.text}</ListItemLink></ListItem>\n  ))}\n</List>",
       "examples": [
         "<LinkList />"
       ],


### PR DESCRIPTION
Adds `key` prop to element arrays – without keys React can't reliably keep track of elements in an array